### PR TITLE
Migrate to stdlib context

### DIFF
--- a/poller.go
+++ b/poller.go
@@ -1,9 +1,8 @@
 package diodes
 
 import (
+	"context"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 // Diode is any implementation of a diode.

--- a/poller_test.go
+++ b/poller_test.go
@@ -1,10 +1,9 @@
 package diodes_test
 
 import (
+	"context"
 	"sync"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"code.cloudfoundry.org/go-diodes"
 

--- a/waiter.go
+++ b/waiter.go
@@ -1,9 +1,8 @@
 package diodes
 
 import (
+	"context"
 	"sync"
-
-	"golang.org/x/net/context"
 )
 
 // Waiter will use a conditional mutex to alert the reader to when data is

--- a/waiter_test.go
+++ b/waiter_test.go
@@ -1,9 +1,8 @@
 package diodes_test
 
 import (
+	"context"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"code.cloudfoundry.org/go-diodes"
 


### PR DESCRIPTION
The `x/net/context` is deprecated since Go 1.7.