### PR TITLE
Fix segmentation fault on 32-bit ARM

### DIFF
--- a/many_to_one.go
+++ b/many_to_one.go
@@ -9,8 +9,8 @@ import (
 // ManyToOne diode is optimal for many writers (go-routines B-n) and a single
 // reader (go-routine A). It is not thread safe for multiple readers.
 type ManyToOne struct {
-	buffer     []unsafe.Pointer
 	writeIndex uint64
+	buffer     []unsafe.Pointer
 	readIndex  uint64
 	alerter    Alerter
 }


### PR DESCRIPTION
Fix segmentation fault on 32-bit ARM by moving atomic uint64 to be the first field in ManyToOne.

writeIndex is written to atomically, which means it must be 64-bit aligned on 32-bit 386 and ARM platforms. When the buffer slice is above it, it becomes unaligned and segfaults on the call to atomic.AddUint64().

See https://github.com/golang/go/issues/23345