### PR TITLE
Refactor diodes into subpackage diode

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         go-version-file: 'go.mod'
         check-latest: true
-    - run: go run github.com/onsi/ginkgo/v2/ginkgo -r --procs=2 --compilers=2 --randomize-all --randomize-suites --fail-on-pending --keep-going --race --trace
+    - run: go test -race ./...
 
   vet:
     runs-on: ubuntu-latest

--- a/diode/diode.go
+++ b/diode/diode.go
@@ -1,0 +1,152 @@
+package diode
+
+import (
+	"sync/atomic"
+	"unsafe"
+)
+
+// GenericData is the data type the diode operates on.
+type GenericData unsafe.Pointer
+
+type bucket struct {
+	data GenericData
+	seq  uint64 // The write index at the time of writing.
+}
+
+// Diode is a ring buffer manipulated via atomics and optimized for optimized
+// for high throughput scenarios where losing data is acceptable. A diode does
+// its best to not "push back" on the producer.
+type Diode struct {
+	buf      []unsafe.Pointer
+	writeIdx uint64
+	readIdx  uint64
+	opts     options
+}
+
+// New creates a diode with the given size and options.
+func New(size int, opts ...Option) *Diode {
+	d := &Diode{
+		buf: make([]unsafe.Pointer, size),
+	}
+
+	for _, opt := range opts {
+		opt.apply(&d.opts)
+	}
+
+	if d.opts.rep == nil {
+		d.opts.rep = reporter{}
+	}
+
+	return d
+}
+
+// Set sets the data in the next slot of the ring buffer.
+func (d *Diode) Set(gd GenericData) {
+	if d.opts.safe {
+		d.setSafely(gd)
+	} else {
+		d.set(gd)
+	}
+}
+
+func (d *Diode) set(gd GenericData) {
+	idx := d.writeIdx % uint64(len(d.buf))
+
+	newBucket := &bucket{
+		data: gd,
+		seq:  d.writeIdx,
+	}
+	d.writeIdx++
+
+	atomic.StorePointer(&d.buf[idx], unsafe.Pointer(newBucket))
+}
+
+func (d *Diode) setSafely(gd GenericData) {
+	for {
+		writeIndex := atomic.AddUint64(&d.writeIdx, 1)
+		idx := writeIndex % uint64(len(d.buf))
+		old := atomic.LoadPointer(&d.buf[idx])
+
+		if old != nil &&
+			(*bucket)(old) != nil &&
+			(*bucket)(old).seq > writeIndex-uint64(len(d.buf)) {
+			go d.opts.rep.Warn("diode set collision (consider using a larger diode)")
+			continue
+		}
+
+		newBucket := &bucket{
+			data: gd,
+			seq:  writeIndex,
+		}
+
+		if !atomic.CompareAndSwapPointer(&d.buf[idx], old, unsafe.Pointer(newBucket)) {
+			go d.opts.rep.Warn("diode set collision (consider using a larger diode)")
+			continue
+		}
+
+		return
+	}
+}
+
+// TryNext will attempt to read from the next slot of the ring buffer. If there
+// is not data available, it will return (nil, false).
+func (d *Diode) TryNext() (gd GenericData, ok bool) {
+	// Read a value from the ring buffer based on the readIndex.
+	idx := d.readIdx % uint64(len(d.buf))
+	result := (*bucket)(atomic.SwapPointer(&d.buf[idx], nil))
+
+	// When the result is nil that means the writer has not had the
+	// opportunity to write a value into the diode. This value must be ignored
+	// and the read head must not increment.
+	if result == nil {
+		return nil, false
+	}
+
+	// When the seq value is less than the current read index that means a
+	// value was read from idx that was previously written but has since has
+	// been dropped. This value must be ignored and the read head must not
+	// increment.
+	//
+	// The simulation for this scenario assumes the fast forward occurred as
+	// detailed below.
+	//
+	// 5. The reader reads again getting seq 5. It then reads again expecting
+	//    seq 6 but gets seq 2. This is a read of a stale value that was
+	//    effectively "dropped" so the read fails and the read head stays put.
+	//    `| 4 | 5 | 2 | 3 |` r: 7, w: 6
+	//
+	if result.seq < d.readIdx {
+		return nil, false
+	}
+
+	// When the seq value is greater than the current read index that means a
+	// value was read from idx that overwrote the value that was expected to
+	// be at this idx. This happens when the writer has lapped the reader. The
+	// reader needs to catch up to the writer so it moves its write head to
+	// the new seq, effectively dropping the messages that were not read in
+	// between the two values.
+	//
+	// Here is a simulation of this scenario:
+	//
+	// 1. Both the read and write heads start at 0.
+	//    `| nil | nil | nil | nil |` r: 0, w: 0
+	// 2. The writer fills the buffer.
+	//    `| 0 | 1 | 2 | 3 |` r: 0, w: 4
+	// 3. The writer laps the read head.
+	//    `| 4 | 5 | 2 | 3 |` r: 0, w: 6
+	// 4. The reader reads the first value, expecting a seq of 0 but reads 4,
+	//    this forces the reader to fast forward to 5.
+	//    `| 4 | 5 | 2 | 3 |` r: 5, w: 6
+	//
+	if result.seq > d.readIdx {
+		go d.opts.rep.Alert(result.seq - d.readIdx)
+		d.readIdx = result.seq
+	}
+
+	// Only increment read index if a regular read occurred (where seq was
+	// equal to readIdx) or a value was read that caused a fast forward
+	// (where seq was greater than readIdx).
+	//
+	d.readIdx++
+	return result.data, true
+}

--- a/diode/diode.go
+++ b/diode/diode.go
@@ -50,12 +50,18 @@ func New[T any](size int, opts ...Option) *Diode[T] {
 // Set sets the data into the next slot of the ring buffer. This function is
 // only thread-safe if the Diode was created WithManyWriters.
 func (d *Diode[T]) Set(data *T) {
-	copy := *data
+	setFunc := d.set
 	if d.opts.safe {
-		d.safelySet(&copy)
-	} else {
-		d.set(&copy)
+		setFunc = d.safelySet
 	}
+
+	if d.opts.copy {
+		copy := *data
+		setFunc(&copy)
+		return
+	}
+
+	setFunc(data)
 }
 
 // set sets the data quickly into the next slot of the ring buffer. This is not

--- a/diode/diode_test.go
+++ b/diode/diode_test.go
@@ -6,42 +6,45 @@ import (
 )
 
 func TestTryNext(t *testing.T) {
-	d := New(5)
+	d := New[string](5)
 
 	s := "test"
-	d.Set(GenericData(&s))
+	d.Set(&s)
 
-	gd, ok := d.TryNext()
+	str, ok := d.TryNext()
 	if !ok {
 		t.Errorf("TryNext() = _, %t; want _, true", ok)
 	}
-	if d := *(*string)(gd); d != s {
-		t.Errorf("TryNext() = %v, true; want %v, true", d, s)
+	if *str != s {
+		t.Errorf("TryNext() = %v, true; want %v, true", *str, s)
 	}
 }
 
 func TestTryNext_Empty(t *testing.T) {
-	d := New(5)
+	d := New[string](5)
 
-	_, ok := d.TryNext()
+	val, ok := d.TryNext()
 	if ok {
 		t.Errorf("TryNext() = _, %t; want _, false", ok)
+	}
+	if val != nil {
+		t.Errorf("TryNext() = %+v, false; want nil, false", val)
 	}
 }
 
 func TestTryNext_Overwrite(t *testing.T) {
-	d := New(5)
+	d := New[string](5)
 
 	for i := range [7]int{} {
 		s := fmt.Sprintf("test-%d", i)
-		d.Set(GenericData(&s))
+		d.Set(&s)
 	}
 
-	gd, ok := d.TryNext()
+	str, ok := d.TryNext()
 	if !ok {
 		t.Errorf("TryNext() = _, %t; want _, true", ok)
 	}
-	if d := *(*string)(gd); d != "test-5" {
-		t.Errorf("TryNext() = %v, true; want test-5, true", d)
+	if *str != "test-5" {
+		t.Errorf("TryNext() = %v, true; want test-5, true", *str)
 	}
 }

--- a/diode/diode_test.go
+++ b/diode/diode_test.go
@@ -1,0 +1,47 @@
+package diode
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestTryNext(t *testing.T) {
+	d := New(5)
+
+	s := "test"
+	d.Set(GenericData(&s))
+
+	gd, ok := d.TryNext()
+	if !ok {
+		t.Errorf("TryNext() = _, %t; want _, true", ok)
+	}
+	if d := *(*string)(gd); d != s {
+		t.Errorf("TryNext() = %v, true; want %v, true", d, s)
+	}
+}
+
+func TestTryNext_Empty(t *testing.T) {
+	d := New(5)
+
+	_, ok := d.TryNext()
+	if ok {
+		t.Errorf("TryNext() = _, %t; want _, false", ok)
+	}
+}
+
+func TestTryNext_Overwrite(t *testing.T) {
+	d := New(5)
+
+	for i := range [7]int{} {
+		s := fmt.Sprintf("test-%d", i)
+		d.Set(GenericData(&s))
+	}
+
+	gd, ok := d.TryNext()
+	if !ok {
+		t.Errorf("TryNext() = _, %t; want _, true", ok)
+	}
+	if d := *(*string)(gd); d != "test-5" {
+		t.Errorf("TryNext() = %v, true; want test-5, true", d)
+	}
+}

--- a/diode/diode_test.go
+++ b/diode/diode_test.go
@@ -5,46 +5,148 @@ import (
 	"testing"
 )
 
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	d := New[string](5)
+
+	if size := len(d.buf); size != 5 {
+		t.Errorf("New Diode buffer size = %d; want 5", size)
+	}
+	if d.readIdx != 0 {
+		t.Errorf("New Diode readIdx = %d; want 0", d.readIdx)
+	}
+	var i uint64
+	i = ^i
+	if d.writeIdx != i {
+		t.Errorf("New Diode writeIdx = %d; want %d", d.writeIdx, i)
+	}
+}
+
+func TestSet(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		d    *Diode[string]
+	}{
+		{name: "one writer", d: New[string](5)},
+		{name: "many writers", d: New[string](5, WithManyWriters())},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				oldReadIdx  = tc.d.readIdx
+				oldWriteIdx = tc.d.writeIdx
+			)
+
+			data := "test"
+			tc.d.Set(&data)
+
+			if b := (*bucket[string])(tc.d.buf[tc.d.writeIdx]); *b.data != data || b.seq != tc.d.writeIdx {
+				t.Errorf(`buf[0] = {data: %+v, seq: %d}; want {data: test, seq: %d}`, *b.data, b.seq, tc.d.writeIdx)
+			}
+			if tc.d.readIdx != oldReadIdx {
+				t.Errorf("readIdx = %d; want %d", tc.d.readIdx, oldReadIdx)
+			}
+			if tc.d.writeIdx != oldWriteIdx+1 {
+				t.Errorf("writeIdx = %d; want %d", tc.d.writeIdx, oldWriteIdx+1)
+			}
+		})
+	}
+}
+
 func TestTryNext(t *testing.T) {
-	d := New[string](5)
+	t.Parallel()
 
-	s := "test"
-	d.Set(&s)
-
-	str, ok := d.TryNext()
-	if !ok {
-		t.Errorf("TryNext() = _, %t; want _, true", ok)
+	type test struct {
+		name    string
+		preFill int
+		readIdx uint64
+		result  string
+		ok      bool
 	}
-	if *str != s {
-		t.Errorf("TryNext() = %v, true; want %v, true", *str, s)
+
+	tests := []test{
+		{name: "simple", preFill: 1, readIdx: 1, result: "test-0", ok: true},
+		{name: "empty", preFill: 0, readIdx: 0, result: "", ok: false},
+		{name: "overwrite", preFill: 7, readIdx: 6, result: "test-5", ok: true},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			d := New[string](5)
+
+			for i := 0; i < tc.preFill; i++ {
+				s := fmt.Sprintf("test-%d", i)
+				d.Set(&s)
+			}
+
+			result, ok := d.TryNext()
+
+			if d.readIdx != tc.readIdx {
+				t.Errorf("readIdx = %d; want %d", d.readIdx, tc.readIdx)
+			}
+			if ok != tc.ok {
+				t.Errorf("TryNext() = _, %t; want _, %t", ok, tc.ok)
+			}
+			if (!ok && result != nil) || (ok && *result != tc.result) {
+				t.Errorf("TryNext() = %s, _; want %s, _", *result, tc.result)
+			}
+		})
 	}
 }
 
-func TestTryNext_Empty(t *testing.T) {
-	d := New[string](5)
+func BenchmarkSet(b *testing.B) {
+	data := "test"
 
-	val, ok := d.TryNext()
-	if ok {
-		t.Errorf("TryNext() = _, %t; want _, false", ok)
+	tests := []struct {
+		name string
+		d    *Diode[string]
+	}{
+		{name: "one writer", d: New[string](5)},
+		{name: "many writers", d: New[string](5, WithManyWriters())},
 	}
-	if val != nil {
-		t.Errorf("TryNext() = %+v, false; want nil, false", val)
+
+	for _, tc := range tests {
+		tc := tc
+		for k := 10; k < 10001; k *= 10 {
+			b.Run(fmt.Sprintf("%s %d", tc.name, k), func(b *testing.B) {
+				b.ResetTimer()
+
+				for i := 0; i < b.N; i++ {
+					tc.d.Set(&data)
+				}
+			})
+		}
 	}
 }
 
-func TestTryNext_Overwrite(t *testing.T) {
-	d := New[string](5)
+func BenchmarkTryNext(b *testing.B) {
+	data := "test"
 
-	for i := range [7]int{} {
-		s := fmt.Sprintf("test-%d", i)
-		d.Set(&s)
-	}
+	for k := 10; k < 10001; k *= 10 {
+		for j := 10; j < 10001; j *= 10 {
+			b.Run(fmt.Sprintf("size %d pre-insert %d", k, j), func(b *testing.B) {
+				d := New[string](k)
 
-	str, ok := d.TryNext()
-	if !ok {
-		t.Errorf("TryNext() = _, %t; want _, true", ok)
-	}
-	if *str != "test-5" {
-		t.Errorf("TryNext() = %v, true; want test-5, true", *str)
+				for i := 0; i < j; i++ {
+					d.Set(&data)
+				}
+
+				b.ResetTimer()
+
+				for i := 0; i < b.N; i++ {
+					_, _ = d.TryNext()
+				}
+			})
+		}
 	}
 }

--- a/diode/doc.go
+++ b/diode/doc.go
@@ -1,0 +1,4 @@
+// Package diode implements a ring buffer that's optimized for high-throughput
+// scenarios where losing data is acceptable. The ring buffer does its best to
+// not "push back" on the producer.
+package diode

--- a/diode/options.go
+++ b/diode/options.go
@@ -3,6 +3,7 @@ package diode
 type options struct {
 	rep  Reporter
 	safe bool
+	copy bool
 }
 
 // Option configures how we set up the diode.
@@ -32,11 +33,22 @@ func WithReporter(r Reporter) Option {
 
 // WithManyWriters returns an Option which tells the diode to use a many-to-one
 // configuration that is safe for many writers (on go-routines B-n), and a
-// single reader (on go-routine A).
+// single reader (on go-routine A). Note that this option affects performance.
 func WithManyWriters() Option {
 	return &optionFunc{
 		f: func(o *options) {
 			o.safe = true
+		},
+	}
+}
+
+// WithCopy returns an Option which tells the diode to make copies of data
+// rather than reusing pointers passed into Set. Note that this option affects
+// performance.
+func WithCopy() Option {
+	return &optionFunc{
+		f: func(o *options) {
+			o.copy = true
 		},
 	}
 }

--- a/diode/options.go
+++ b/diode/options.go
@@ -1,0 +1,42 @@
+package diode
+
+type options struct {
+	rep  Reporter
+	safe bool
+}
+
+// Option configures how we set up the diode.
+type Option interface {
+	apply(*options)
+}
+
+// optionFunc wraps a function that modifies options into an implementation of
+// the Option interface.
+type optionFunc struct {
+	f func(*options)
+}
+
+func (of *optionFunc) apply(o *options) {
+	of.f(o)
+}
+
+// WithReporter returns an Option which sets a Reporter for the diode to use for
+// alerts and warnings.
+func WithReporter(r Reporter) Option {
+	return &optionFunc{
+		f: func(o *options) {
+			o.rep = r
+		},
+	}
+}
+
+// WithManyWriters returns an Option which tells the diode to use a many-to-one
+// configuration that is safe for many writers (on go-routines B-n), and a
+// single reader (on go-routine A).
+func WithManyWriters() Option {
+	return &optionFunc{
+		f: func(o *options) {
+			o.safe = true
+		},
+	}
+}

--- a/diode/reporter.go
+++ b/diode/reporter.go
@@ -1,0 +1,17 @@
+package diode
+
+// Reporter is used to report alerts and warnings.
+type Reporter interface {
+	Alert(dropped uint64) // Some values were overwritten.
+	Warn(msg string)      // A warning message was generated.
+}
+
+// Assert reporter implements Reporter.
+var _ Reporter = reporter{}
+
+// reporter is a struct that satisfies the Reporter interface, but
+// doesn't actually do anything. Just in case no Reporter is set.
+type reporter struct{}
+
+func (r reporter) Alert(dropped uint64) {}
+func (r reporter) Warn(msg string)      {}

--- a/diode/reporter_test.go
+++ b/diode/reporter_test.go
@@ -21,6 +21,8 @@ func (fr *fakeReporter) Alert(dropped uint64) {
 func (fr *fakeReporter) Warn(msg string) {}
 
 func TestWithReporter(t *testing.T) {
+	t.Parallel()
+
 	done := make(chan struct{})
 	fr := &fakeReporter{done: done}
 	d := New[string](5, WithReporter(fr))

--- a/diode/reporter_test.go
+++ b/diode/reporter_test.go
@@ -20,14 +20,14 @@ func (fr *fakeReporter) Alert(dropped uint64) {
 }
 func (fr *fakeReporter) Warn(msg string) {}
 
-func TestReporter(t *testing.T) {
+func TestWithReporter(t *testing.T) {
 	done := make(chan struct{})
 	fr := &fakeReporter{done: done}
-	d := New(5, WithReporter(fr))
+	d := New[string](5, WithReporter(fr))
 
 	for i := range [7]int{} {
 		s := fmt.Sprintf("test-%d", i)
-		d.Set(GenericData(&s))
+		d.Set(&s)
 	}
 
 	_, _ = d.TryNext()

--- a/diode/reporter_test.go
+++ b/diode/reporter_test.go
@@ -1,0 +1,46 @@
+package diode
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+type fakeReporter struct {
+	done chan struct{}
+
+	alerts  int
+	dropped uint64
+}
+
+func (fr *fakeReporter) Alert(dropped uint64) {
+	fr.alerts++
+	fr.dropped += dropped
+	close(fr.done)
+}
+func (fr *fakeReporter) Warn(msg string) {}
+
+func TestReporter(t *testing.T) {
+	done := make(chan struct{})
+	fr := &fakeReporter{done: done}
+	d := New(5, WithReporter(fr))
+
+	for i := range [7]int{} {
+		s := fmt.Sprintf("test-%d", i)
+		d.Set(GenericData(&s))
+	}
+
+	_, _ = d.TryNext()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+	}
+
+	if fr.alerts != 1 {
+		t.Errorf("Alert() called %d times; want 1 time", fr.alerts)
+	}
+	if fr.dropped != 5 {
+		t.Errorf("Alert(%d) called; want Alert(5)", fr.dropped)
+	}
+}


### PR DESCRIPTION
# Description

Shuffle packages around to make imports more clean.

i.e. `code.cloudfoundry.org/go-diodes` ->
  * `code.cloudfoundry.org/go-diodes/diode`
  * `code.cloudfoundry.org/go-diodes/poller`
  * `code.cloudfoundry.org/go-diodes/waiter`
 
Also, use generics such that importing packages won't have to redefine diodes to use their own custom types.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Testing performed?

- [x] Unit tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [x] I have added testing for my changes

